### PR TITLE
(feat) improve eslint config, format files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,10 +9,17 @@ module.exports = {
     browser: true,
     es6: true,
     node: true,
-    "jest/globals": true
+    'jest/globals': true
   },
   plugins: ['jest'],
-  extends: ['@vue/prettier', 'plugin:vue/recommended'],
+  extends: [
+    'prettier',
+    'prettier/standard',
+    'plugin:vue/recommended',
+    'eslint:recommended',
+    'prettier/vue',
+    'plugin:prettier/recommended'
+  ],
   rules: {
     'no-debugger': process.env.NODE_ENV === 'production' ? 2 : 0,
     'require-yield': ['warn'],

--- a/apps/player/src/tabs/Tabs.vue
+++ b/apps/player/src/tabs/Tabs.vue
@@ -42,35 +42,47 @@ import { setStyles } from '@podlove/utils/dom'
 
 const tabs = {
   InfoTab: () =>
-    import(/* webpackChunkName: "info-tab" */
-    /* webpackMode: "lazy" */
-    /* webpackPreload: true */
-    '../info'),
+    import(
+      /* webpackChunkName: "info-tab" */
+      /* webpackMode: "lazy" */
+      /* webpackPreload: true */
+      '../info'
+    ),
   ChaptersTab: () =>
-    import(/* webpackChunkName: "chapters-tab" */
-    /* webpackMode: "lazy" */
-    /* webpackPreload: true */
-    '../chapters'),
+    import(
+      /* webpackChunkName: "chapters-tab" */
+      /* webpackMode: "lazy" */
+      /* webpackPreload: true */
+      '../chapters'
+    ),
   FilesTab: () =>
-    import(/* webpackChunkName: "files-tab" */
-    /* webpackMode: "lazy" */
-    /* webpackPreload: true */
-    '../files'),
+    import(
+      /* webpackChunkName: "files-tab" */
+      /* webpackMode: "lazy" */
+      /* webpackPreload: true */
+      '../files'
+    ),
   ShareTab: () =>
-    import(/* webpackChunkName: "share-tab" */
-    /* webpackMode: "lazy" */
-    /* webpackPreload: true */
-    '../share'),
+    import(
+      /* webpackChunkName: "share-tab" */
+      /* webpackMode: "lazy" */
+      /* webpackPreload: true */
+      '../share'
+    ),
   AudioTab: () =>
-    import(/* webpackChunkName: "audio-tab" */
-    /* webpackMode: "lazy" */
-    /* webpackPreload: true */
-    '../audio'),
+    import(
+      /* webpackChunkName: "audio-tab" */
+      /* webpackMode: "lazy" */
+      /* webpackPreload: true */
+      '../audio'
+    ),
   TranscriptsTab: () =>
-    import(/* webpackChunkName: "transcripts-tab" */
-    /* webpackMode: "lazy" */
-    /* webpackPreload: true */
-    '../transcripts')
+    import(
+      /* webpackChunkName: "transcripts-tab" */
+      /* webpackMode: "lazy" */
+      /* webpackPreload: true */
+      '../transcripts'
+    )
 }
 
 export default {

--- a/package-lock.json
+++ b/package-lock.json
@@ -294,7 +294,6 @@
 			"version": "7.4.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.4.0.tgz",
 			"integrity": "sha512-uTNi8pPYyUH2eWHyYWWSYJKwKg34hhgl4/dbejEjL+64OhbHjTX7wEVWMQl82tEmdDsGeu77+s8HHLS627h6OQ==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/plugin-syntax-object-rest-spread": "^7.2.0"
@@ -678,17 +677,6 @@
 				"invariant": "^2.2.2",
 				"js-levenshtein": "^1.1.3",
 				"semver": "^5.3.0"
-			},
-			"dependencies": {
-				"@babel/plugin-proposal-object-rest-spread": {
-					"version": "7.4.3",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.4.3.tgz",
-					"integrity": "sha512-xC//6DNSSHVjq8O2ge0dyYlhshsH4T7XdCVoxbi5HzLYWfsC5ooFlJjrXk8RcAT+hjHAK9UjBXdylzSoDK3t4g==",
-					"requires": {
-						"@babel/helper-plugin-utils": "^7.0.0",
-						"@babel/plugin-syntax-object-rest-spread": "^7.2.0"
-					}
-				}
 			}
 		},
 		"@babel/runtime": {
@@ -2672,15 +2660,6 @@
 				"webpack-hot-middleware": "^2.24.3"
 			},
 			"dependencies": {
-				"@babel/plugin-proposal-object-rest-spread": {
-					"version": "7.4.3",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.4.3.tgz",
-					"integrity": "sha512-xC//6DNSSHVjq8O2ge0dyYlhshsH4T7XdCVoxbi5HzLYWfsC5ooFlJjrXk8RcAT+hjHAK9UjBXdylzSoDK3t4g==",
-					"requires": {
-						"@babel/helper-plugin-utils": "^7.0.0",
-						"@babel/plugin-syntax-object-rest-spread": "^7.2.0"
-					}
-				},
 				"autoprefixer": {
 					"version": "9.5.1",
 					"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.5.1.tgz",
@@ -2899,9 +2878,9 @@
 			}
 		},
 		"@types/babel-types": {
-			"version": "7.0.6",
-			"resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-7.0.6.tgz",
-			"integrity": "sha512-8zYZyy2kgwBXdz2j8Ix7LOghGiZbOiHf6vqmmBX1r76FdAzVNv7cODyJTEglUWiOdRnXh0s/o58neUwv5vaitQ=="
+			"version": "7.0.7",
+			"resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-7.0.7.tgz",
+			"integrity": "sha512-dBtBbrc+qTHy1WdfHYjBwRln4+LWqASWakLHsWHR2NWHIFkv4W3O070IGoGLEBrJBvct3r0L1BUPuvURi7kYUQ=="
 		},
 		"@types/babel__core": {
 			"version": "7.1.1",
@@ -3050,22 +3029,16 @@
 						"uniq": "^1.0.1"
 					}
 				},
+				"prettier": {
+					"version": "1.16.3",
+					"resolved": "https://registry.npmjs.org/prettier/-/prettier-1.16.3.tgz",
+					"integrity": "sha512-kn/GU6SMRYPxUakNXhpP0EedT/KmaPzr0H5lIsDogrykbaxOpOfAFfk5XA7DZrJyMAv1wlMV3CPcZruGXVVUZw=="
+				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
-			}
-		},
-		"@vue/eslint-config-prettier": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@vue/eslint-config-prettier/-/eslint-config-prettier-4.0.1.tgz",
-			"integrity": "sha512-rJEDXPb61Hfgg8GllO3XXFP98bcIxdNNHSrNcxP/vBSukOolgOwQyZJ5f5z/c7ViPyh5/IDlC4qBnhx/0n+I4g==",
-			"dev": true,
-			"requires": {
-				"eslint-config-prettier": "^3.3.0",
-				"eslint-plugin-prettier": "^3.0.0",
-				"prettier": "^1.15.2"
 			}
 		},
 		"@vue/test-utils": {
@@ -3314,9 +3287,9 @@
 			"dev": true
 		},
 		"address": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/address/-/address-1.0.3.tgz",
-			"integrity": "sha512-z55ocwKBRLryBs394Sm3ushTtBeg6VAeuku7utSoSnsJKvKcnXFIyC6vh27n3rXyxSgkJBBCAvyOn7gSUcTYjg=="
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/address/-/address-1.1.0.tgz",
+			"integrity": "sha512-4diPfzWbLEIElVG4AnqP+00SULlPzNuyJFNnmMrLgyaxG6tZXJ1sn7mjBu4fHrJE+Yp/jgylOweJn2xsLMFggQ=="
 		},
 		"after": {
 			"version": "0.8.2",
@@ -7351,13 +7324,20 @@
 			}
 		},
 		"browserslist": {
-			"version": "4.5.4",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.4.tgz",
-			"integrity": "sha512-rAjx494LMjqKnMPhFkuLmLp8JWEX0o8ADTGeAbOqaF+XCvYLreZrG5uVjnPBlAQ8REZK4pzXGvp0bWgrFtKaag==",
+			"version": "4.5.5",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.5.tgz",
+			"integrity": "sha512-0QFO1r/2c792Ohkit5XI8Cm8pDtZxgNl2H6HU4mHrpYz7314pEYcsAVVatM0l/YmxPnEzh9VygXouj4gkFUTKA==",
 			"requires": {
-				"caniuse-lite": "^1.0.30000955",
-				"electron-to-chromium": "^1.3.122",
-				"node-releases": "^1.1.13"
+				"caniuse-lite": "^1.0.30000960",
+				"electron-to-chromium": "^1.3.124",
+				"node-releases": "^1.1.14"
+			},
+			"dependencies": {
+				"caniuse-lite": {
+					"version": "1.0.30000963",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000963.tgz",
+					"integrity": "sha512-n4HUiullc7Lw0LyzpeLa2ffP8KxFBGdxqD/8G3bSL6oB758hZ2UE2CVK+tQN958tJIi0/tfpjAc67aAtoHgnrQ=="
+				}
 			}
 		},
 		"bs-logger": {
@@ -8198,12 +8178,9 @@
 			}
 		},
 		"comma-separated-tokens": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.5.tgz",
-			"integrity": "sha512-Cg90/fcK93n0ecgYTAz1jaA3zvnQ0ExlmKY1rdbyHqAx6BHxwoJc+J7HDu0iuQ7ixEs1qaa+WyQ6oeuBpYP1iA==",
-			"requires": {
-				"trim": "0.0.1"
-			}
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.6.tgz",
+			"integrity": "sha512-f20oA7jsrrmERTS70r3tmRSxR8IJV2MTN7qe6hzgX+3ARfXrdMJFvGWvWQK0xpcBurg9j9eO2MiqzZ8Y+/UPCA=="
 		},
 		"commander": {
 			"version": "2.20.0",
@@ -9771,9 +9748,9 @@
 			}
 		},
 		"csstype": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.3.tgz",
-			"integrity": "sha512-rINUZXOkcBmoHWEyu7JdHu5JMzkGRoMX4ov9830WNgxf5UYxcBUO0QTKAqeJ5EZfSdlrcJYkC8WwfVW7JYi4yg=="
+			"version": "2.6.4",
+			"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.4.tgz",
+			"integrity": "sha512-lAJUJP3M6HxFXbqtGRc0iZrdyeN+WzOWeY0q/VnFzI+kqVrYIzC7bWlKqCW7oCIdzoPkvfp82EVvrTlQ8zsWQg=="
 		},
 		"currently-unhandled": {
 			"version": "0.4.1",
@@ -10840,9 +10817,9 @@
 			}
 		},
 		"eslint-config-prettier": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-3.6.0.tgz",
-			"integrity": "sha512-ixJ4U3uTLXwJts4rmSVW/lMXjlGwCijhBJHk8iVqKKSifeI0qgFEfWl8L63isfc8Od7EiBALF6BX3jKLluf/jQ==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-4.1.0.tgz",
+			"integrity": "sha512-zILwX9/Ocz4SV2vX7ox85AsrAgXV3f2o2gpIicdMIOra48WYqgUnWNH/cR/iHtmD2Vb3dLSC3LiEJnS05Gkw7w==",
 			"dev": true,
 			"requires": {
 				"get-stdin": "^6.0.0"
@@ -11522,9 +11499,9 @@
 			"dev": true
 		},
 		"focus-lock": {
-			"version": "0.6.2",
-			"resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.6.2.tgz",
-			"integrity": "sha512-Wuq6TSOgsGQmzbpvinl1TcEw4BAUhD9T06myl5HvaBlO0geAz9ABtqBIqPkkNyO3AgPzEDazetL5hSRgj+2iqQ=="
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.6.3.tgz",
+			"integrity": "sha512-EU6ePgEauhWrzJEN5RtG1d1ayrWXhEnfzTjnieHj+jG9tNHDEhKTAnCn1TN3gs9h6XWCDH6cpeX1VXY/lzLwZg=="
 		},
 		"follow-redirects": {
 			"version": "1.7.0",
@@ -11684,11 +11661,13 @@
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -11705,7 +11684,8 @@
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
@@ -11834,6 +11814,7 @@
 				"minimatch": {
 					"version": "3.0.4",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -16276,9 +16257,9 @@
 			}
 		},
 		"markdown-to-jsx": {
-			"version": "6.9.3",
-			"resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-6.9.3.tgz",
-			"integrity": "sha512-iXteiv317VZd1vk/PBH5MWMD4r0XWekoWCHRVVadBcnCtxavhtfV1UaEaQgq9KyckTv31L60ASh5ZVVrOh37Qg==",
+			"version": "6.9.4",
+			"resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-6.9.4.tgz",
+			"integrity": "sha512-Fvx2ZhiknGmcLsWVjIq6MmiN9gcCot8w+jzwN2mLXZcQsJGRN3Zes5Sp5M9YNIzUy/sDyuOTjimFdtAcvvmAPQ==",
 			"requires": {
 				"prop-types": "^15.6.2",
 				"unquote": "^1.1.0"
@@ -16997,9 +16978,9 @@
 			}
 		},
 		"node-releases": {
-			"version": "1.1.14",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.14.tgz",
-			"integrity": "sha512-d58EpVZRhQE60kWiWUaaPlK9dyC4zg3ZoMcHcky2d4hDksyQj0rUozwInOl0C66mBsqo01Tuns8AvxnL5S7PKg==",
+			"version": "1.1.17",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.17.tgz",
+			"integrity": "sha512-/SCjetyta1m7YXLgtACZGDYJdCSIBAWorDWkGCGZlydP2Ll7J48l7j/JxNYZ+xsgSPbWfdulVS/aY+GdjUsQ7Q==",
 			"requires": {
 				"semver": "^5.3.0"
 			}
@@ -18909,9 +18890,10 @@
 			"dev": true
 		},
 		"prettier": {
-			"version": "1.16.3",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-1.16.3.tgz",
-			"integrity": "sha512-kn/GU6SMRYPxUakNXhpP0EedT/KmaPzr0H5lIsDogrykbaxOpOfAFfk5XA7DZrJyMAv1wlMV3CPcZruGXVVUZw=="
+			"version": "1.17.0",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-1.17.0.tgz",
+			"integrity": "sha512-sXe5lSt2WQlCbydGETgfm1YBShgOX4HxQkFPvbxkcwgDvGDeqVau8h+12+lmSVlP3rHPz0oavfddSZg/q+Szjw==",
+			"dev": true
 		},
 		"prettier-linter-helpers": {
 			"version": "1.0.0",
@@ -19488,12 +19470,12 @@
 			}
 		},
 		"react-color": {
-			"version": "2.17.0",
-			"resolved": "https://registry.npmjs.org/react-color/-/react-color-2.17.0.tgz",
-			"integrity": "sha512-kJfE5tSaFe6GzalXOHksVjqwCPAsTl+nzS9/BWfP7j3EXbQ4IiLAF9sZGNzk3uq7HfofGYgjmcUgh0JP7xAQ0w==",
+			"version": "2.17.1",
+			"resolved": "https://registry.npmjs.org/react-color/-/react-color-2.17.1.tgz",
+			"integrity": "sha512-S+I6TkUKJaqfALLkAIfiCZ/MANQyy7dKkf7g9ZU5GTUy2rf8c2Rx62otyvADAviWR+6HRkzdf2vL1Qvz9goCLQ==",
 			"requires": {
 				"@icons/material": "^0.2.4",
-				"lodash": ">4.17.4",
+				"lodash": "^4.17.11",
 				"material-colors": "^1.2.1",
 				"prop-types": "^15.5.10",
 				"reactcss": "^1.2.0",
@@ -19531,6 +19513,11 @@
 				"text-table": "0.2.0"
 			},
 			"dependencies": {
+				"address": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/address/-/address-1.0.3.tgz",
+					"integrity": "sha512-z55ocwKBRLryBs394Sm3ushTtBeg6VAeuku7utSoSnsJKvKcnXFIyC6vh27n3rXyxSgkJBBCAvyOn7gSUcTYjg=="
+				},
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
@@ -19674,18 +19661,18 @@
 			}
 		},
 		"react-draggable": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-3.2.1.tgz",
-			"integrity": "sha512-r+3Bs9InID2lyIEbR8UIRVtpn4jgu1ArFEZgIy8vibJjijLSdNLX7rH9U68BBVD4RD9v44RXbaK4EHLyKXzNQw==",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-3.3.0.tgz",
+			"integrity": "sha512-U7/jD0tAW4T0S7DCPK0kkKLyL0z61sC/eqU+NUfDjnq+JtBKaYKDHpsK2wazctiA4alEzCXUnzkREoxppOySVw==",
 			"requires": {
 				"classnames": "^2.2.5",
 				"prop-types": "^15.6.0"
 			}
 		},
 		"react-error-overlay": {
-			"version": "5.1.4",
-			"resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-5.1.4.tgz",
-			"integrity": "sha512-fp+U98OMZcnduQ+NSEiQa4s/XMsbp+5KlydmkbESOw4P69iWZ68ZMFM5a2BuE0FgqPBKApJyRuYHR95jM8lAmg=="
+			"version": "5.1.5",
+			"resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-5.1.5.tgz",
+			"integrity": "sha512-O9JRum1Zq/qCPFH5qVEvDDrVun8Jv9vbHtZXCR1EuRj9sKg1xJTlHxBzU6AkCzpvxRLuiY4OKImy3cDLQ+UTdg=="
 		},
 		"react-fast-compare": {
 			"version": "2.0.4",
@@ -19698,12 +19685,12 @@
 			"integrity": "sha1-LEIWypAD7PnYruTxHmog9ylXeSU="
 		},
 		"react-focus-lock": {
-			"version": "1.18.3",
-			"resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-1.18.3.tgz",
-			"integrity": "sha512-4fPAHnsr8oCYPgVmcMZ8NbAE9jm/OshPjXEM5PHseu2lDernzm/b1sHhYzZUO4OoW9D/u1AQsV6n4trRllow7w==",
+			"version": "1.19.1",
+			"resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-1.19.1.tgz",
+			"integrity": "sha512-TPpfiack1/nF4uttySfpxPk4rGZTLXlaZl7ncZg/ELAk24Iq2B1UUaUioID8H8dneUXqznT83JTNDHDj+kwryw==",
 			"requires": {
 				"@babel/runtime": "^7.0.0",
-				"focus-lock": "^0.6.0",
+				"focus-lock": "^0.6.3",
 				"prop-types": "^15.6.2",
 				"react-clientside-effect": "^1.2.0"
 			}
@@ -19819,9 +19806,9 @@
 			}
 		},
 		"react-select": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/react-select/-/react-select-2.4.2.tgz",
-			"integrity": "sha512-5xFOQ6JJktkY5NTaHrc6x9mKwIjhNIiBkGic1j71uyY+ulFpRFra6f4WKLd9fuCylk4WjLpO5zDhdF4CAcwFzA==",
+			"version": "2.4.3",
+			"resolved": "https://registry.npmjs.org/react-select/-/react-select-2.4.3.tgz",
+			"integrity": "sha512-cmxNaiHpviRYkojeW9rGEUJ4jpX7QTmPe2wcscwA4d1lStzw/cJtr4ft5H2O/YhfpkrcwaLghu3XmEYdXhBo8Q==",
 			"requires": {
 				"classnames": "^2.2.5",
 				"emotion": "^9.1.2",
@@ -20191,9 +20178,9 @@
 			}
 		},
 		"refractor": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/refractor/-/refractor-2.8.0.tgz",
-			"integrity": "sha512-w+jG49/1MX60GeE9u8lyx1KYMBRdAHjOIfgcDJ0wq2ogOnEmab0MgIj+AtPq6kelw0mr1l9U0i2rFvLlOCkxiw==",
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/refractor/-/refractor-2.9.0.tgz",
+			"integrity": "sha512-lCnCYvXpqd8hC7ksuvo516rz5q4NwzBbq0X5qjH5pxRfcQKiQxKZ8JctrSQmrR/7pcV2TRrs9TT+Whmq/wtluQ==",
 			"requires": {
 				"hastscript": "^5.0.0",
 				"parse-entities": "^1.1.2",
@@ -21332,12 +21319,9 @@
 			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
 		},
 		"space-separated-tokens": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.2.tgz",
-			"integrity": "sha512-G3jprCEw+xFEs0ORweLmblJ3XLymGGr6hxZYTYZjIlvDti9vOBUjRQa1Rzjt012aRrocKstHwdNi+F7HguPsEA==",
-			"requires": {
-				"trim": "0.0.1"
-			}
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.3.tgz",
+			"integrity": "sha512-/M5RAdBuQlSDPNfA5ube+fkHbHyY08pMuADLmsAQURzo56w90r681oiOoz3o3ZQyWdSeNucpTFjL+Ggd5qui3w=="
 		},
 		"spawn-promise": {
 			"version": "0.1.8",
@@ -21811,9 +21795,9 @@
 			}
 		},
 		"svgo": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/svgo/-/svgo-1.2.1.tgz",
-			"integrity": "sha512-Y1+LyT4/y1ms4/0yxPMSlvx6dIbgklE9w8CIOnfeoFGB74MEkq8inSfEr6NhocTaFbyYp0a1dvNgRKGRmEBlzA==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/svgo/-/svgo-1.2.2.tgz",
+			"integrity": "sha512-rAfulcwp2D9jjdGu+0CuqlrAUin6bBWrpoqXWwKDZZZJfXcUXQSxLJOFJCQCSA0x0pP2U0TxSlJu2ROq5Bq6qA==",
 			"requires": {
 				"chalk": "^2.4.1",
 				"coa": "^2.0.2",
@@ -21822,7 +21806,7 @@
 				"css-tree": "1.0.0-alpha.28",
 				"css-url-regex": "^1.1.0",
 				"csso": "^3.5.1",
-				"js-yaml": "^3.13.0",
+				"js-yaml": "^3.13.1",
 				"mkdirp": "~0.5.1",
 				"object.values": "^1.1.0",
 				"sax": "~1.2.4",
@@ -22362,11 +22346,6 @@
 			"requires": {
 				"punycode": "^2.1.0"
 			}
-		},
-		"trim": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
-			"integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
 		},
 		"trim-newlines": {
 			"version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -5,29 +5,32 @@
     "format": "eslint --fix '**/*.{js,vue}'",
     "lint": "eslint -f codeframe '**/*.{js,vue}'",
     "test": "jest",
-    "test:dev": "jest --watchAll"
+    "test:dev": "jest --watchAll",
+    "eslint-check": "eslint --print-config .eslintrc.js | eslint-config-prettier-check"
   },
   "devDependencies": {
+    "@babel/core": "7.4.3",
     "@babel/plugin-proposal-object-rest-spread": "7.4.0",
     "@babel/plugin-syntax-dynamic-import": "7.2.0",
-    "@babel/plugin-transform-runtime": "7.4.3",
     "@babel/plugin-transform-modules-commonjs": "7.4.3",
-    "@babel/core": "7.4.3",
+    "@babel/plugin-transform-runtime": "7.4.3",
     "@types/jest": "24.0.11",
-    "babel-jest": "24.6.0",
-    "@vue/eslint-config-prettier": "4.0.1",
     "@vue/test-utils": "1.0.0-beta.29",
-    "vue-jest": "4.0.0-beta.2",
-    "jest-serializer-vue": "2.0.2",
-    "babel-eslint": "10.0.1",
     "babel-bridge": "1.12.11",
+    "babel-eslint": "10.0.1",
+    "babel-jest": "24.6.0",
     "eslint": "5.15.3",
-    "eslint-plugin-vue": "5.2.2",
+    "eslint-config-prettier": "^4.1.0",
     "eslint-plugin-jest": "22.4.1",
+    "eslint-plugin-prettier": "^3.0.1",
+    "eslint-plugin-vue": "^5.2.2",
     "husky": "1.3.1",
     "jest": "24.6.0",
+    "jest-serializer-vue": "2.0.2",
     "lerna": "3.4.3",
-    "lint-staged": "8.1.5"
+    "lint-staged": "8.1.5",
+    "prettier": "^1.17.0",
+    "vue-jest": "4.0.0-beta.2"
   },
   "lint-staged": {
     "linters": {


### PR DESCRIPTION
Since the plugin @vue/eslint-config-prettier warns that it is not meant for use outside of vue-cli.
I installed the ESLint plugins  and modified the ESLint config. 
A format run afterwards only changed the included Tabs.vue.